### PR TITLE
Add "dist" to default ignore paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
 				},
 				"commentAnchors.workspace.excludeFiles": {
 					"type": "string",
-					"default": "**/{node_modules,.git,.idea,target,out,build,vendor}/**/*",
+					"default": "**/{node_modules,.git,.idea,target,out,build,dist,vendor}/**/*",
 					"description": "The glob pattern of the files that will be excluded from matching by Comment Anchors",
 					"scope": "window"
 				},


### PR DESCRIPTION
`dist` is another common build directory name, and seems like it might be helpful to include for others.